### PR TITLE
Be/user mutation fix

### DIFF
--- a/code/api/src/modules/user/mutations.js
+++ b/code/api/src/modules/user/mutations.js
@@ -49,6 +49,21 @@ export const userUpdate = {
       type: GraphQLInt
     },
 
+    name: {
+      name: 'name',
+      type: GraphQLString
+    },
+
+    role: {
+      name: 'role',
+      type: GraphQLString
+    },
+
+    twitter: {
+      name: 'twitter',
+      type: GraphQLString
+    },
+
     image: {
       name: 'image',
       type: GraphQLString

--- a/code/api/src/modules/user/resolvers.js
+++ b/code/api/src/modules/user/resolvers.js
@@ -80,7 +80,7 @@ export async function getGenders() {
 
 
 // Update
-export async function update(parentValue, { name, description, email, image, streetAddress, city, state, zip, country }, { auth }) {
+export async function update(parentValue, { name, description, email, image, streetAddress, city, state, zip, country, twitter }, { auth }) {
   if (auth.isAuthenticated) {
     await models.User.update(
       {
@@ -91,7 +91,8 @@ export async function update(parentValue, { name, description, email, image, str
         streetAddress,
         city,
         state,
-        country
+        country,
+        twitter
       },
       {
         where: { id: auth.user.id }

--- a/code/api/src/modules/user/types.js
+++ b/code/api/src/modules/user/types.js
@@ -19,6 +19,7 @@ const UserType = new GraphQLObjectType({
     state: { type: GraphQLString },
     zip: { type: GraphQLString },
     country: { type: GraphQLString },
+    twitter: { type: GraphQLString },
     createdAt: { type: GraphQLString },
     updatedAt: { type: GraphQLString }
   })


### PR DESCRIPTION
### Description
Add fix to API repo to make successful mutations
Modifies `user/` : `resolvers.js, types.js, mutations.js`

### Changes include
- [x] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

### Other comments
- Name, Twitter were not included in the `update()` params 
- added twitter to `update()` fields
- add `name, role, twitter` to mutations
- add `twitter: { type: GraphQLString }` to types
